### PR TITLE
add webpack fallback for https module

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  resolve: {
+    fallback: {
+      https: false,
+    },
+  },
+};


### PR DESCRIPTION
As mentioned in #3 to support `https`, I added the webpack config.

close #3 